### PR TITLE
Fix favicon for share links

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <html lang="en" class="dark">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" href="/favicon-spinning.png" type="image/png">
+    <link rel="icon" href="/favicon.ico" type="image/x-icon">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     
     <!-- FK Grotesk Font -->


### PR DESCRIPTION
Update the favicon used for share link previews from `favicon-spinning.png` to `favicon.ico` to ensure consistency across the site.